### PR TITLE
torch 1.11.0 compatibility

### DIFF
--- a/models/experimental.py
+++ b/models/experimental.py
@@ -122,6 +122,8 @@ def attempt_load(weights, map_location=None):
     for m in model.modules():
         if type(m) in [nn.Hardswish, nn.LeakyReLU, nn.ReLU, nn.ReLU6, nn.SiLU]:
             m.inplace = True  # pytorch 1.7.0 compatibility
+        elif type(m) is nn.Upsample:
+            m.recompute_scale_factor = None  # torch 1.11.0 compatibility
         elif type(m) is Conv:
             m._non_persistent_buffers_set = set()  # pytorch 1.6.0 compatibility
 


### PR DESCRIPTION
It solves compatibility problem (AttributeError: 'Upsample' object has no attribute 'recompute_scale_factor') when using torch >=1.11.0 version. More details can be found here: https://github.com/ultralytics/yolov5/issues/6948
Related PR: https://github.com/ultralytics/yolov5/pull/6932